### PR TITLE
fix: canonical url

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -124,7 +124,7 @@ html_sidebars = {"**": ["side-nav.html"]}
 htmlhelp_basename = "ScyllaDocumentationdoc"
 
 # URL which points to the root of the HTML documentation.
-html_baseurl = "https://shopping-cart.scylladb.com/"
+html_baseurl = "https://shopping-cart.scylladb.com"
 
 # Dictionary of values to pass into the template engine’s context for all pages
 html_context = {"html_baseurl": html_baseurl}


### PR DESCRIPTION
## Motivation

Removes the extra slash added to canonical URLs.

We had some issues adding this project to the docs search engine:

 > The project generates canonical URLs as follows: https://shopping-cart.scylladb.com**/**/stable/data-model.html (see the extra slash.

## How to test

Compare with project with correct config: https://github.com/scylladb/sphinx-scylladb-theme/blob/master/docs/source/conf.py#L137